### PR TITLE
JS loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ var config = require('get-config').sync(__dirname + '/config');
 ## Supported Formats
 
 * [INI](http://en.wikipedia.org/wiki/INI_file): `.ini`, `.cfg`, `.conf` → (requires `npm install ini`)
+* [JS](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules): `.js`
 * [JSON](http://json.org/): `.json`
 * [TOML](https://github.com/toml-lang/toml): `.toml` → (requires `npm install toml`)
 * [XML](http://www.w3.org/XML/): `.xml` → (requires `npm install xml2json`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ var Promise = require('bluebird');
 
 var _loaders = {
   ini: require('./loaders/ini'),
+  js: require('./loaders/js'),
   json: require('./loaders/json'),
   toml: require('./loaders/toml'),
   xml: require('./loaders/xml'),
@@ -61,6 +62,12 @@ function _loadDir(dir) {
           fn: _loaders.ini
         });
       });
+      _.merge([], filesByExtName['.js']).forEach(function (file) {
+        loadTasks.push({
+          filepath: path.resolve(dir, file),
+          fn: _loaders.js
+        });
+      });
       _.merge([], filesByExtName['.json']).forEach(function (file) {
         loadTasks.push({
           filepath: path.resolve(dir, file),
@@ -101,7 +108,7 @@ function _loadDir(dir) {
                 .then(function (loaded) {
                   var extname = path.extname(loadTask.filepath).toLowerCase();
                   var key = path.basename(loadTask.filepath, extname);
-                  result[key] = _.merge({}, result[key], loaded);
+                  result[key] = _.isFunction(loaded) ? loaded : _.merge({}, result[key], loaded);
                 })
                 .catch(function (err) {
                   console.error('Failed to load file: ' + loadTask.filepath);

--- a/lib/loaders/js.js
+++ b/lib/loaders/js.js
@@ -1,0 +1,5 @@
+var Promise = require('bluebird');
+
+module.exports = function (path) {
+  return Promise.resolve(require(path));
+};


### PR DESCRIPTION
Addressing #3
Added the ability to pull in a `.js` file exported value;

If the exported value is a function, it is merely replaced, not merged.
This allows a deferred object of sorts, where users can pass the config object.
## Example:

```
var config = require('get-config').sync(__dirname + '/../config');
var webpackConfig = config.webpack(config);
```
### `config/webpack.js`

```
var webpack = require('webpack');
module.exports = function(config) {
  webpackConfig = {};

  if (config.devMode) {
    webpackConfig.devtool = 'sourcemap';
    webpackConfig.debug = true;
  } else {
    webpackConfig.plugins = [
      new webpack.optimize.DedupePlugin()
    ]
  }

  return webpackConfig;
};
```
