### PR TITLE
Bumped deasync version to work with node4/5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "bluebird": "^2.9.7",
-    "deasync": "0.0.10",
+    "deasync": "^0.1.4",
     "get-env": "0.4.0",
     "lodash": "^3.6.0"
   },


### PR DESCRIPTION
There's a problem on installing old deasync on latest node versions. This fixes it.
